### PR TITLE
bug fixes and performance tweaks

### DIFF
--- a/Assets/_Metro/Resources/Prefabs/Train.prefab
+++ b/Assets/_Metro/Resources/Prefabs/Train.prefab
@@ -87,6 +87,7 @@ GameObject:
   - component: {fileID: 6439959121776170142}
   - component: {fileID: 2368136335061161323}
   - component: {fileID: 350480276601677397}
+  - component: {fileID: 1071487710872033757}
   m_Layer: 5
   m_Name: SeatUI
   m_TagString: Untagged
@@ -101,7 +102,7 @@ RectTransform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 983167881747482999}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalRotation: {x: 0.7071068, y: 0, z: 0, w: 0.7071068}
   m_LocalPosition: {x: 0, y: 0, z: 0.03}
   m_LocalScale: {x: 0.1, y: 0.1, z: 0.1}
   m_Children:
@@ -109,7 +110,7 @@ RectTransform:
   - {fileID: 532877892333878243}
   m_Father: {fileID: 2005789692743078721}
   m_RootOrder: 1
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_LocalEulerAnglesHint: {x: 90, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
   m_AnchoredPosition: {x: 0, y: 0.0127}
@@ -176,6 +177,19 @@ MonoBehaviour:
   m_BlockingMask:
     serializedVersion: 2
     m_Bits: 4294967295
+--- !u!114 &1071487710872033757
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 983167881747482999}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 80ba14c10e062e346aae8aa8365b5a23, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  disabledOption: 0
 --- !u!1 &1029770810645898671
 GameObject:
   m_ObjectHideFlags: 0
@@ -188,6 +202,7 @@ GameObject:
   - component: {fileID: 6468443568616170968}
   - component: {fileID: 8099443930563547848}
   - component: {fileID: 8889895256079403936}
+  - component: {fileID: 2685795676609884722}
   - component: {fileID: 3997219423031540652}
   m_Layer: 0
   m_Name: Train
@@ -203,7 +218,7 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1029770810645898671}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalRotation: {x: -0.49991274, y: 0.50008726, z: 0.49991274, w: 0.50008726}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 2, y: 2, z: 2}
   m_Children:
@@ -211,7 +226,7 @@ Transform:
   - {fileID: 3976493591737305107}
   m_Father: {fileID: 0}
   m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_LocalEulerAnglesHint: {x: -89.98, y: 90, z: 0}
 --- !u!114 &6468443568616170968
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -325,6 +340,19 @@ MonoBehaviour:
   onHoverExited:
     m_PersistentCalls:
       m_Calls: []
+--- !u!65 &2685795676609884722
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1029770810645898671}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 0.07, y: 0.03, z: 0.03}
+  m_Center: {x: -0.015, y: 0, z: 0}
 --- !u!114 &3997219423031540652
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -892,27 +920,27 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: fae5d70c167526040ade4938dda91209, type: 3}
       propertyPath: m_LocalRotation.w
-      value: 0.50008726
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: fae5d70c167526040ade4938dda91209, type: 3}
       propertyPath: m_LocalRotation.x
-      value: -0.49991274
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: fae5d70c167526040ade4938dda91209, type: 3}
       propertyPath: m_LocalRotation.y
-      value: 0.50008726
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: fae5d70c167526040ade4938dda91209, type: 3}
       propertyPath: m_LocalRotation.z
-      value: 0.49991274
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: fae5d70c167526040ade4938dda91209, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
-      value: -89.98
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: fae5d70c167526040ade4938dda91209, type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
-      value: 90
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: fae5d70c167526040ade4938dda91209, type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
@@ -955,7 +983,7 @@ MeshCollider:
   m_GameObject: {fileID: 1310963891508972000}
   m_Material: {fileID: 0}
   m_IsTrigger: 0
-  m_Enabled: 1
+  m_Enabled: 0
   serializedVersion: 4
   m_Convex: 0
   m_CookingOptions: 30

--- a/Assets/_Metro/Scenes/Metro.unity
+++ b/Assets/_Metro/Scenes/Metro.unity
@@ -1032,35 +1032,39 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 787585537385602698, guid: 1606a7868b13138479f1a52f92cd0511, type: 3}
       propertyPath: m_AnchorMax.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 787585537385602698, guid: 1606a7868b13138479f1a52f92cd0511, type: 3}
       propertyPath: m_AnchorMin.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 787585537385602698, guid: 1606a7868b13138479f1a52f92cd0511, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 0.125
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 787585537385602698, guid: 1606a7868b13138479f1a52f92cd0511, type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -2
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2601823252921355568, guid: 1606a7868b13138479f1a52f92cd0511, type: 3}
+      propertyPath: m_IsActive
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2616590800617982325, guid: 1606a7868b13138479f1a52f92cd0511, type: 3}
       propertyPath: m_AnchorMax.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2616590800617982325, guid: 1606a7868b13138479f1a52f92cd0511, type: 3}
       propertyPath: m_AnchorMin.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2616590800617982325, guid: 1606a7868b13138479f1a52f92cd0511, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 0.125
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2616590800617982325, guid: 1606a7868b13138479f1a52f92cd0511, type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -0.3
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2636988880125205324, guid: 1606a7868b13138479f1a52f92cd0511, type: 3}
       propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Mode
@@ -1112,19 +1116,19 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2960301465893497168, guid: 1606a7868b13138479f1a52f92cd0511, type: 3}
       propertyPath: m_AnchorMax.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2960301465893497168, guid: 1606a7868b13138479f1a52f92cd0511, type: 3}
       propertyPath: m_AnchorMin.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2960301465893497168, guid: 1606a7868b13138479f1a52f92cd0511, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 0.125
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2960301465893497168, guid: 1606a7868b13138479f1a52f92cd0511, type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -0.9
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 3810835806710997274, guid: 1606a7868b13138479f1a52f92cd0511, type: 3}
       propertyPath: m_RootOrder
@@ -1184,67 +1188,67 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4970507271305427047, guid: 1606a7868b13138479f1a52f92cd0511, type: 3}
       propertyPath: m_AnchorMax.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4970507271305427047, guid: 1606a7868b13138479f1a52f92cd0511, type: 3}
       propertyPath: m_AnchorMin.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4970507271305427047, guid: 1606a7868b13138479f1a52f92cd0511, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 0.125
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4970507271305427047, guid: 1606a7868b13138479f1a52f92cd0511, type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -0.5
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5223344114204222333, guid: 1606a7868b13138479f1a52f92cd0511, type: 3}
       propertyPath: m_AnchorMax.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5223344114204222333, guid: 1606a7868b13138479f1a52f92cd0511, type: 3}
       propertyPath: m_AnchorMin.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5223344114204222333, guid: 1606a7868b13138479f1a52f92cd0511, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 0.125
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5223344114204222333, guid: 1606a7868b13138479f1a52f92cd0511, type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -0.7
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 6150206231985481495, guid: 1606a7868b13138479f1a52f92cd0511, type: 3}
       propertyPath: m_AnchorMax.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 6150206231985481495, guid: 1606a7868b13138479f1a52f92cd0511, type: 3}
       propertyPath: m_AnchorMin.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 6150206231985481495, guid: 1606a7868b13138479f1a52f92cd0511, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 0.125
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 6150206231985481495, guid: 1606a7868b13138479f1a52f92cd0511, type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -1.2
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 6301571921691509536, guid: 1606a7868b13138479f1a52f92cd0511, type: 3}
       propertyPath: m_AnchorMax.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 6301571921691509536, guid: 1606a7868b13138479f1a52f92cd0511, type: 3}
       propertyPath: m_AnchorMin.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 6301571921691509536, guid: 1606a7868b13138479f1a52f92cd0511, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 0.125
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 6301571921691509536, guid: 1606a7868b13138479f1a52f92cd0511, type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -1.6
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 6718849251617842520, guid: 1606a7868b13138479f1a52f92cd0511, type: 3}
       propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.size
@@ -1276,19 +1280,19 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8091305496073458440, guid: 1606a7868b13138479f1a52f92cd0511, type: 3}
       propertyPath: m_AnchorMax.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8091305496073458440, guid: 1606a7868b13138479f1a52f92cd0511, type: 3}
       propertyPath: m_AnchorMin.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8091305496073458440, guid: 1606a7868b13138479f1a52f92cd0511, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 0.125
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8091305496073458440, guid: 1606a7868b13138479f1a52f92cd0511, type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -0.100000024
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8328365827470270201, guid: 1606a7868b13138479f1a52f92cd0511, type: 3}
       propertyPath: m_Name

--- a/Assets/_Metro/Scripts/MetroManager.cs
+++ b/Assets/_Metro/Scripts/MetroManager.cs
@@ -77,7 +77,6 @@ public class MetroManager : MonoBehaviour, IMixedRealityTeleportHandler {
             new liblsl.StreamInfo("EventMarker", "Markers", 1, 0, liblsl.channel_format_t.cf_string);
         markerStream = new liblsl.StreamOutlet(inf);
 
-
         // Spawn in the games.
 
         if (numGamesToSpawn <= 0) {
@@ -87,6 +86,7 @@ public class MetroManager : MonoBehaviour, IMixedRealityTeleportHandler {
         for (uint i = 0; i < numGamesToSpawn; i++) {
             var newMetroGame = (new GameObject("Game " + games.Count)).AddComponent<MetroGame>();
             newMetroGame.gameId = i;
+            newMetroGame.transform.parent = this.transform; //less clutter in scene hiearchy
             games.Add(newMetroGame);
             newMetroGame.transform.position = GetGameLocation(newMetroGame.gameId);
 
@@ -269,7 +269,7 @@ public class MetroManager : MonoBehaviour, IMixedRealityTeleportHandler {
     /// Refresh the UI. EX: When selected game is reset or when switching the selected game.
     /// </summary>
     private void RefreshUI() {
-        foreach (var l in lineUIs) {
+        foreach (TransportLineUI l in lineUIs) {
             l.SetLine(null);
         }
 

--- a/Assets/_Metro/Scripts/TrackSegment.cs
+++ b/Assets/_Metro/Scripts/TrackSegment.cs
@@ -61,8 +61,11 @@ public class TrackSegment : MonoBehaviour,  IMixedRealityPointerHandler {
             lineRenderer.SetPosition(i, p); 
         }
 
-        lineRenderer.BakeMesh(mesh, true);
-        meshCollider.sharedMesh = mesh;
+        if(line.stops.Count != 0) // Can't bake mesh from line renderer with empty position vector
+        {
+            lineRenderer.BakeMesh(mesh, true);
+            meshCollider.sharedMesh = mesh;
+        }
         needsUpdate = false;
     }
 

--- a/Assets/_Metro/Scripts/Tracks.cs
+++ b/Assets/_Metro/Scripts/Tracks.cs
@@ -165,6 +165,7 @@ public class Tracks : MonoBehaviour {
         // Debug.Log("UpdateUISegment");
         // Debug.Log(i + " " + stopIndex);
         // Debug.Log(uiSegments.Count + " " + cp.Count);
+        if(cp.Count == 0) this.UpdateControlPoints();
         uiSegments[i].gameObject.SetActive(true);
         if(stopIndex == -1) stopIndex = 0;
         uiSegments[i].cp[0] = cp[3*stopIndex];


### PR DESCRIPTION
Train.prefab: removed mesh collider from train geometry object and replaced with box collider on train prefab root.  This saves performance and gets rid of exception from the MRTK interactable script.  Also added selected object culling script to train seat UI to not render UI elements from non selected games

MetroManager.cs: Games get created with metro manager as their transform parent to reduce clutter from 100 games in the scene hierarchy

Track.cs: Call UpdateControlPoints() to populate cp array when beginning to track the first track segment of a transport line  this was causing a bunch of errors when creating new lines.

TrackSegment.cs:  Doesn't create the mesh for interaction if there is no line to interact with.  This might not be the best way to implement this but it would cause 300 errors on game start, 3 per game.